### PR TITLE
Ignore world in death check

### DIFF
--- a/scripting/lilac/lilac_aimbot.sp
+++ b/scripting/lilac/lilac_aimbot.sp
@@ -58,8 +58,8 @@ public Action event_player_death_tf2(Event event, const char[] name, bool dontBr
 
 	GetEventString(event, "weapon_logclassname", wep, sizeof(wep), "");
 
-	// Ignore sentries in TF2.
-	if (!strncmp(wep, "obj_", 4, false))
+	// Ignore sentries & world in TF2.
+	if (!strncmp(wep, "obj_", 4, false) || !strncmp(wep, "world", 5, false))
 		return Plugin_Continue;
 
 	userid = GetEventInt(event, "attacker", -1);


### PR DESCRIPTION
If someone uses a splash weapon that can hit multiple people with one projectile and a death trigger goes off it counts as kills. This would trip the AimSnap check.