### PR TITLE
Skip aimbot check if killer is dead

### DIFF
--- a/scripting/lilac/lilac_aimbot.sp
+++ b/scripting/lilac/lilac_aimbot.sp
@@ -85,6 +85,7 @@ void event_death_shared(int userid, int client, int victim, bool skip_delta)
 		|| !is_player_valid(client)
 		|| !is_player_valid(victim)
 		|| IsFakeClient(client)
+		|| !IsPlayerAlive(client)
 		|| playerinfo_banned_flags[client][CHEAT_AIMBOT]
 		|| GetClientTime(client) < 10.1)
 		return;


### PR DESCRIPTION
it will cause wrong detection.