### PR TITLE
Add notice about TF2Classic-Tools requirement

### DIFF
--- a/scripting/lilac.sp
+++ b/scripting/lilac.sp
@@ -16,6 +16,12 @@
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+/* Uncomment below line to compile for Team Fortress 2 Classic.
+ * Note: Doing so means the compiled plugin won't work correctly
+ * for other source games. 
+ * Note #2: You need SM-TF2Clasic-Tools to compile the plugin: https://github.com/tf2classic/SM-TF2Classic-Tools */
+//#define TF2C
+
 #include <sourcemod>
 #include <sdktools_engine>
 #include <sdktools_entoutput>
@@ -30,10 +36,6 @@
 #endif
 #define REQUIRE_PLUGIN
 #define REQUIRE_EXTENSIONS
-/* Uncomment below line to compile for Team Fortress 2 Classic.
- * Note: Doing so means the compiled plugin won't work correctly
- * for other source games. */
-//#define TF2C
 
 #pragma semicolon 1
 #pragma newdecls required

--- a/scripting/lilac.sp
+++ b/scripting/lilac.sp
@@ -17,9 +17,11 @@
 */
 
 /* Uncomment below line to compile for Team Fortress 2 Classic.
+ * You'll need SourceMod 1.10 and SM-TF2Clasic-Tools to compile, if you decide to.
  * Note: Doing so means the compiled plugin won't work correctly
  * for other source games. 
- * Note #2: You need SM-TF2Clasic-Tools to compile the plugin: https://github.com/tf2classic/SM-TF2Classic-Tools */
+ * SourceMod 1.10: https://www.sourcemod.net/downloads.php?branch=1.10-dev
+ * SM-TF2Clasic-Tools: https://github.com/tf2classic/SM-TF2Classic-Tools */
 //#define TF2C
 
 #include <sourcemod>

--- a/scripting/lilac.sp
+++ b/scripting/lilac.sp
@@ -16,13 +16,6 @@
 	along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
-/* Uncomment this line to compile for Team Fortress 2 Classic.
- * Note: Doing so means the compiled plugin won't work correctly
- * for other source games. */
-// #define TF2C
-
-
 #include <sourcemod>
 #include <sdktools_engine>
 #include <sdktools_entoutput>
@@ -37,7 +30,10 @@
 #endif
 #define REQUIRE_PLUGIN
 #define REQUIRE_EXTENSIONS
-
+/* Uncomment below line to compile for Team Fortress 2 Classic.
+ * Note: Doing so means the compiled plugin won't work correctly
+ * for other source games. */
+//#define TF2C
 
 #pragma semicolon 1
 #pragma newdecls required


### PR DESCRIPTION
Putting defines above and removing the comment and compiling displays `lilac.sp(32) : error 417: cannot read from file: "tf2c"` error. This commit fixes that by putting the TF2C define below other defines, so it should compile without any issues.