### PR TITLE
Add support for DeathMatch.TF and administration-agnostic bans

### DIFF
--- a/scripting/lilac.sp
+++ b/scripting/lilac.sp
@@ -198,6 +198,7 @@ public void OnAllPluginsLoaded()
 	sourcebanspp_exist = LibraryExists("sourcebans++");
 	sourcebans_exist = LibraryExists("sourcebans");
 	materialadmin_exist = LibraryExists("materialadmin");
+	dmtf_exist = LibaryExists("dmtf");
 
 	if (LibraryExists("updater"))
 		lilac_update_url();
@@ -229,6 +230,8 @@ public void OnLibraryAdded(const char []name)
 		sourcebans_exist = true;
 	else if (StrEqual(name, "materialadmin"))
 		materialadmin_exist = true;
+	else if (StrEqual(name, "dmtf"))
+		dmtf_exist = true;
 	else if (StrEqual(name, "updater"))
 		lilac_update_url();
 }
@@ -241,6 +244,8 @@ public void OnLibraryRemoved(const char []name)
 		sourcebans_exist = false;
 	else if (StrEqual(name, "materialadmin"))
 		materialadmin_exist = false;
+	else if (StrEqual(name, "dmtf"))
+		dmtf_exist = false
 }
 
 void lilac_update_url()

--- a/scripting/lilac.sp
+++ b/scripting/lilac.sp
@@ -198,7 +198,7 @@ public void OnAllPluginsLoaded()
 	sourcebanspp_exist = LibraryExists("sourcebans++");
 	sourcebans_exist = LibraryExists("sourcebans");
 	materialadmin_exist = LibraryExists("materialadmin");
-	dmtf_exist = LibaryExists("dmtf");
+	dmtf_exist = LibraryExists("dmtf");
 
 	if (LibraryExists("updater"))
 		lilac_update_url();
@@ -245,7 +245,7 @@ public void OnLibraryRemoved(const char []name)
 	else if (StrEqual(name, "materialadmin"))
 		materialadmin_exist = false;
 	else if (StrEqual(name, "dmtf"))
-		dmtf_exist = false
+		dmtf_exist = false;
 }
 
 void lilac_update_url()

--- a/scripting/lilac/lilac_config.sp
+++ b/scripting/lilac/lilac_config.sp
@@ -31,7 +31,10 @@ void lilac_config_setup()
 		FCVAR_PROTECTED, true, 0.0, true, 1.0);
 	hcvar[CVAR_MA] = new Convar("lilac_materialadmin", "1",
 		"Ban players via Material-Admin (Fork of Sourcebans++. If it isn't installed, will default to sourcebans++ or basebans).",
-		FCVAR_PROTECTED, true, 0.0, true, 1.0);
+	FCVAR_PROTECTED, true, 0.0, true, 1.0);
+	hcvar[CVAR_DMTF] = new Convar("lilac_dmtf", "1",
+		"Ban players via DMTF. Not available for most servers. If it isn't present, will default to MaterialAdmin, SourceBans++ or basebans",
+	FCVAR_PROTECTED, true, 0.0, true, 1.0);
 	hcvar[CVAR_SOURCEIRC] = new Convar("lilac_sourceirc", "1",
 		"Enable reflecting log messages to SourceIRC channels flagged with 'lilac', if SourceIRC is available.",
 		FCVAR_PROTECTED, true, 0.0, true, 1.0);

--- a/scripting/lilac/lilac_globals.sp
+++ b/scripting/lilac/lilac_globals.sp
@@ -87,8 +87,8 @@
 #define CVAR_AUTO_UPDATE           36
 #define CVAR_SOURCEIRC             37
 #define CVAR_DATABASE              38
-#define CVAR_MAX                   39
-#define CVAR_DMTF		   40
+#define CVAR_DMTF                  39
+#define CVAR_MAX		   40
 
 #define BHOP_INDEX_MIN     0
 #define BHOP_INDEX_JUMP    1

--- a/scripting/lilac/lilac_globals.sp
+++ b/scripting/lilac/lilac_globals.sp
@@ -88,6 +88,7 @@
 #define CVAR_SOURCEIRC             37
 #define CVAR_DATABASE              38
 #define CVAR_MAX                   39
+#define CVAR_DMTF		   40
 
 #define BHOP_INDEX_MIN     0
 #define BHOP_INDEX_JUMP    1

--- a/scripting/lilac/lilac_globals.sp
+++ b/scripting/lilac/lilac_globals.sp
@@ -176,6 +176,7 @@ Handle forwardhandleallow = INVALID_HANDLE;
 bool sourcebans_exist = false;
 bool sourcebanspp_exist = false;
 bool materialadmin_exist = false;
+bool dmtf_exist = false;
 
 /* Logging.
  * Todo: Might wanna move a lot of this variables to

--- a/scripting/lilac/lilac_stock.sp
+++ b/scripting/lilac/lilac_stock.sp
@@ -300,7 +300,8 @@ void lilac_ban_client(int client, int cheat)
 	}
 
 
-	BanClient(client, get_ban_length(cheat), BANFLAG_AUTO, reason, reason, "lilac", 0);
+	//BanClient(client, get_ban_length(cheat), BANFLAG_AUTO, reason, reason, "lilac", 0);
+	ServerCommand("sm_ban #%d %d %s", GetClientUserId(client), get_ban_length(cheat), reason); // Console command; ban system-agnostic.
 	CreateTimer(5.0, timer_kick, GetClientUserId(client));
 }
 


### PR DESCRIPTION
DeathMatch.TF uses a custom, proprietary, administration system, which isn't present in SourceBans. However, adding every single one is probably not reasonable, which is why I added administration-agnostic bans via the sm_ban command-- simply having the system do things the same way the users do.