### PR TITLE
feat: LittleAntiCheat 1.7.5 (Improve API)

### DIFF
--- a/scripting/include/lilac.inc
+++ b/scripting/include/lilac.inc
@@ -1,0 +1,114 @@
+/*
+	Little Anti-Cheat
+	Copyright (C) 2018-2023 J_Tanzanite
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#if defined _lilac_included
+ #endinput
+#endif
+#define _lilac_included
+
+/* In case anyone wants to change this later on in a pull request or whatever,
+ * DON'T DON'T DON'T DON'T DON'T DON'T DON'T DON'T DON'T DON'T DON'T!!!
+ * ...  DON'T...
+ * These values cannot be changed due to forwards,
+ *     changing them will cause issues for other plugins.
+ * You can add new stuff, but not change the number of anything here. */
+#define CHEAT_ANGLES             0
+#define CHEAT_CHATCLEAR          1
+#define CHEAT_CONVAR             2
+#define CHEAT_NOLERP             3
+#define CHEAT_BHOP               4
+#define CHEAT_AIMBOT             5
+#define CHEAT_AIMLOCK            6
+#define CHEAT_ANTI_DUCK_DELAY    7
+#define CHEAT_NOISEMAKER_SPAM    8
+#define CHEAT_MACRO              9 /* Macros aren't actually cheats, but are forwarded as such. */
+#define CHEAT_NEWLINE_NAME      10
+#define CHEAT_MAX               11
+
+/**
+ * Called when a player is detected cheating.
+ *
+ * @param client     	Client index of the player.
+ * @param cheat     	Cheat type. (See lilac_global #L38-#L48)
+ * @noreturn
+ */
+forward void lilac_cheater_detected(int client, int cheat);
+
+/**
+ * Called before the player is about to be banned for cheating.
+ *
+ * @param client     	Client index of the player.
+ * @param cheat     	Cheat type. (See lilac_global #L38-#L48)
+ * @noreturn
+ */
+forward void lilac_cheater_banned(int client, int cheat);
+
+/**
+ * Interupt the cheat detection process.
+ *
+ * @param client     	Client index of the player.
+ * @param cheat     	Cheat type. (See lilac_global #L38-#L48)
+ * @return				1 If the cheat detection process should be interupted. Otherwise 0.
+ */
+forward bool lilac_allow_cheat_detection(int client, int cheat);
+
+/**
+ * Get the player details informations of the currently cheat flagged.
+ * Best moment to call this function is in the lilac_cheater_detected callback.
+ *
+ * @param client		Client index of the player.
+ * @param buffer		Buffer to store the informations in.
+ * @param maxlen		Maximal length of the buffer.
+ * @return				1 If informations found and stored into buffer. Otherwise -1.
+ */
+native int lilac_GetDetectedInfos(int client, char[] buffer, int maxlen);
+
+// Instead of having to implant this into each plugin who want to use forwards
+stock void GetCheatName(int type, char[] buffer, int maxlen)
+{
+	switch(type)
+	{
+		case CHEAT_ANGLES:Format(buffer, maxlen, "Angles");
+		case CHEAT_CHATCLEAR:Format(buffer, maxlen, "Chat Clear");
+		case CHEAT_CONVAR:Format(buffer, maxlen, "Convar");
+		case CHEAT_NOLERP:Format(buffer, maxlen, "NoLerp");
+		case CHEAT_BHOP:Format(buffer, maxlen, "Bhop");
+		case CHEAT_AIMBOT:Format(buffer, maxlen, "Aimbot");
+		case CHEAT_AIMLOCK:Format(buffer, maxlen, "Aimlock");
+		case CHEAT_ANTI_DUCK_DELAY:Format(buffer, maxlen, "Anti Duck delay");
+		case CHEAT_NOISEMAKER_SPAM:Format(buffer, maxlen, "NoiseMaker spam");
+		case CHEAT_MACRO:Format(buffer, maxlen, "Macro");
+		case CHEAT_NEWLINE_NAME:Format(buffer, maxlen, "NewLine Name");
+	}
+}
+
+public SharedPlugin __pl_lilac =
+{
+	name = "lilac",
+	file = "lilac.smx",
+	#if defined REQUIRE_PLUGIN
+	required = 1
+	#else
+	required = 0
+	#endif
+};
+
+public void __pl_lilac_SetNTVOptional()
+{
+	MarkNativeAsOptional("lilac_GetDetectedInfos");
+}

--- a/scripting/lilac.sp
+++ b/scripting/lilac.sp
@@ -28,6 +28,7 @@
 #include <sdktools_engine>
 #include <sdktools_entoutput>
 #include <convar_class>
+#include <lilac>
 #undef REQUIRE_PLUGIN /* ... */
 #undef REQUIRE_EXTENSIONS
 #if defined TF2C
@@ -208,6 +209,10 @@ public void OnAllPluginsLoaded()
 
 public APLRes AskPluginLoad2(Handle hMyself, bool bLate, char[] sError, int err_max)
 {
+	RegPluginLibrary("lilac");
+
+	CreateNative("lilac_GetDetectedInfos", lilac_native_get_detected_infos);
+
 	/* Been told this isn't needed, but just in case. */
 	MarkNativeAsOptional("SBBanPlayer");
 	MarkNativeAsOptional("SBPP_BanPlayer");

--- a/scripting/lilac/lilac_aimbot.sp
+++ b/scripting/lilac/lilac_aimbot.sp
@@ -323,6 +323,17 @@ static void lilac_detected_aimbot(int client, float delta, float td, int flags)
 	/* Detection expires in 10 minutes. */
 	CreateTimer(600.0, timer_decrement_aimbot, GetClientUserId(client), TIMER_FLAG_NO_MAPCHANGE);
 
+	char sDetails[512];
+	Format(sDetails, sizeof(sDetails),
+			"Detection: %d | Delta: %.0f | TotalDelta: %.0f | Detected:%s%s%s%s%s",
+			aimbot_detection[client], delta, td,
+			((flags & AIMBOT_FLAG_SNAP)      ? " Aim-Snap"     : ""),
+			((flags & AIMBOT_FLAG_SNAP2)     ? " Aim-Snap2"    : ""),
+			((flags & AIMBOT_FLAG_AUTOSHOOT) ? " Autoshoot"    : ""),
+			((flags & AIMBOT_FLAG_REPEAT)    ? " Angle-Repeat" : ""),
+			((td > AIMBOT_MAX_TOTAL_DELTA)   ? " Total-Delta"  : ""));
+
+	lilac_save_player_details(client, sDetails);
 	lilac_forward_client_cheat(client, CHEAT_AIMBOT);
 
 	/* Don't log the first detection. */
@@ -335,13 +346,8 @@ static void lilac_detected_aimbot(int client, float delta, float td, int flags)
 	if (icvar[CVAR_LOG]) {
 		lilac_log_setup_client(client);
 		Format(line_buffer, sizeof(line_buffer),
-			"%s is suspected of using an aimbot (Detection: %d | Delta: %.0f | TotalDelta: %.0f | Detected:%s%s%s%s%s).",
-			line_buffer, aimbot_detection[client], delta, td,
-			((flags & AIMBOT_FLAG_SNAP)      ? " Aim-Snap"     : ""),
-			((flags & AIMBOT_FLAG_SNAP2)     ? " Aim-Snap2"    : ""),
-			((flags & AIMBOT_FLAG_AUTOSHOOT) ? " Autoshoot"    : ""),
-			((flags & AIMBOT_FLAG_REPEAT)    ? " Angle-Repeat" : ""),
-			((td > AIMBOT_MAX_TOTAL_DELTA)   ? " Total-Delta"  : ""));
+			"%s is suspected of using an aimbot (%s).",
+			line_buffer, sDetails);
 
 		lilac_log(true);
 

--- a/scripting/lilac/lilac_aimlock.sp
+++ b/scripting/lilac/lilac_aimlock.sp
@@ -173,6 +173,10 @@ static void lilac_detected_aimlock(int client)
 	/* Detection expires in 10 minutes. */
 	CreateTimer(600.0, timer_decrement_aimlock, GetClientUserId(client), TIMER_FLAG_NO_MAPCHANGE);
 
+	char sDetails[512];
+	Format(sDetails, sizeof(sDetails), "Detection: %d", playerinfo_aimlock[client]);
+
+	lilac_save_player_details(client, sDetails);
 	lilac_forward_client_cheat(client, CHEAT_AIMLOCK);
 
 	/* Don't log the first detection. */
@@ -185,8 +189,8 @@ static void lilac_detected_aimlock(int client)
 	if (icvar[CVAR_LOG]) {
 		lilac_log_setup_client(client);
 		Format(line_buffer, sizeof(line_buffer),
-			"%s is suspected of using an aimlock (Detection: %d).",
-			line_buffer, playerinfo_aimlock[client]);
+			"%s is suspected of using an aimlock (%s).",
+			line_buffer, sDetails);
 
 		lilac_log(true);
 

--- a/scripting/lilac/lilac_angles.sp
+++ b/scripting/lilac/lilac_angles.sp
@@ -81,13 +81,17 @@ static void lilac_detected_angles(int client, float ang[3])
 
 	playerinfo_banned_flags[client][CHEAT_ANGLES] = true;
 
+	char sDetails[512];
+	Format(sDetails, sizeof(sDetails), "Pitch: %.2f, Yaw: %.2f, Roll: %.2f", ang[0], ang[1], ang[2]);
+
+	lilac_save_player_details(client, sDetails);
 	lilac_forward_client_cheat(client, CHEAT_ANGLES);
 
 	if (icvar[CVAR_LOG]) {
 		lilac_log_setup_client(client);
 		Format(line_buffer, sizeof(line_buffer),
-			"%s was detected and banned for Angle-Cheats (Pitch: %.2f, Yaw: %.2f, Roll: %.2f).",
-			line_buffer, ang[0], ang[1], ang[2]);
+			"%s was detected and banned for Angle-Cheats (%s).",
+			line_buffer, sDetails);
 
 		lilac_log(true);
 

--- a/scripting/lilac/lilac_anti_duck_delay.sp
+++ b/scripting/lilac/lilac_anti_duck_delay.sp
@@ -41,6 +41,7 @@ void lilac_anti_duck_delay_check(int client, const int buttons)
 
 	playerinfo_banned_flags[client][CHEAT_ANTI_DUCK_DELAY] = true;
 
+	lilac_save_player_details(client, "N/A");
 	lilac_forward_client_cheat(client, CHEAT_ANTI_DUCK_DELAY);
 
 	if (icvar[CVAR_LOG]) {

--- a/scripting/lilac/lilac_bhop.sp
+++ b/scripting/lilac/lilac_bhop.sp
@@ -104,6 +104,10 @@ static void check_bhop_min(int client)
 
 static void lilac_detected_bhop(int client, bool force_log, bool banning)
 {
+	char sDetails[512];
+	Format(sDetails, sizeof(sDetails), "Detection: %d | Bhops: %d | JumpTicks: %d", detections[client], perfect_bhops[client], jump_ticks[client]);
+
+	lilac_save_player_details(client, sDetails);
 	lilac_forward_client_cheat(client, CHEAT_BHOP);
 
 	/* Detection expires in 10 minutes. */
@@ -121,9 +125,8 @@ static void lilac_detected_bhop(int client, bool force_log, bool banning)
 	if (icvar[CVAR_LOG]) {
 		lilac_log_setup_client(client);
 		Format(line_buffer, sizeof(line_buffer),
-			"%s is suspected of using Bhop (Detection: %d | Bhops: %d | JumpTicks: %d).",
-			line_buffer, detections[client], perfect_bhops[client],
-			jump_ticks[client]);
+			"%s is suspected of using Bhop (%s).",
+			line_buffer, sDetails);
 		lilac_log(true);
 
 		if (icvar[CVAR_LOG_EXTRA] == 2)

--- a/scripting/lilac/lilac_convar.sp
+++ b/scripting/lilac/lilac_convar.sp
@@ -123,13 +123,17 @@ public void query_reply(QueryCookie cookie, int client, ConVarQueryResult result
 	if (lilac_forward_allow_cheat_detection(client, CHEAT_CONVAR) == false)
 		return;
 
+	char sDetails[512];
+	Format(sDetails, sizeof(sDetails), "%s %s", cvarName, cvarValue);
+
+	lilac_save_player_details(client, sDetails);
 	lilac_forward_client_cheat(client, CHEAT_CONVAR);
 
 	if (icvar[CVAR_LOG]) {
 		lilac_log_setup_client(client);
 		Format(line_buffer, sizeof(line_buffer),
-			"%s was detected and banned for an invalid ConVar (%s %s).",
-			line_buffer, cvarName, cvarValue);
+			"%s was detected and banned for an invalid ConVar (%s).",
+			line_buffer, sDetails);
 
 		lilac_log(true);
 

--- a/scripting/lilac/lilac_globals.sp
+++ b/scripting/lilac/lilac_globals.sp
@@ -29,25 +29,6 @@
 #define GAME_L4D2      5
 #define GAME_L4D       6
 
-/* In case anyone wants to change this later on in a pull request or whatever,
- * DON'T DON'T DON'T DON'T DON'T DON'T DON'T DON'T DON'T DON'T DON'T!!!
- * ...  DON'T...
- * These values cannot be changed due to forwards,
- *     changing them will cause issues for other plugins.
- * You can add new stuff, but not change the number of anything here. */
-#define CHEAT_ANGLES             0
-#define CHEAT_CHATCLEAR          1
-#define CHEAT_CONVAR             2
-#define CHEAT_NOLERP             3
-#define CHEAT_BHOP               4
-#define CHEAT_AIMBOT             5
-#define CHEAT_AIMLOCK            6
-#define CHEAT_ANTI_DUCK_DELAY    7
-#define CHEAT_NOISEMAKER_SPAM    8
-#define CHEAT_MACRO              9 /* Macros aren't actually cheats, but are forwarded as such. */
-#define CHEAT_NEWLINE_NAME      10
-#define CHEAT_MAX               11
-
 #define CVAR_ENABLE                 0
 #define CVAR_WELCOME                1
 #define CVAR_SB                     2
@@ -139,7 +120,7 @@
 #define PLUGIN_NAME      "[Lilac] Little Anti-Cheat"
 #define PLUGIN_AUTHOR    "J_Tanzanite"
 #define PLUGIN_DESC      "An opensource Anti-Cheat"
-#define PLUGIN_VERSION   "1.7.4"
+#define PLUGIN_VERSION   "1.7.5"
 #define PLUGIN_URL       "https://github.com/J-Tanzanite/Little-Anti-Cheat"
 
 /* Convars. */
@@ -194,13 +175,14 @@ float playerinfo_angles[MAXPLAYERS + 1][CMD_LENGTH][3];
 float playerinfo_time_usercmd[MAXPLAYERS + 1][CMD_LENGTH];
 float playerinfo_time_forward[MAXPLAYERS + 1][CHEAT_MAX];
 bool playerinfo_banned_flags[MAXPLAYERS + 1][CHEAT_MAX];
+char playerinfo_detected[MAXPLAYERS + 1][1024];
 
 
 /* Forward declarations so we don't need third-party include files. */
 
 #define MA_BAN_STEAM  1
 
-native Function IRC_MsgFlaggedChannels(const char[] flag, const char[] format, any:...);
+native Function IRC_MsgFlaggedChannels(const char[] flag, const char[] format, any ...);
 native Function MABanPlayer(int iClient, int iTarget, int iType, int iTime, char[] sReason);
 native Function SBBanPlayer(int client, int target, int time, const char[] reason);
 native Function SBPP_BanPlayer(int iAdmin, int iTarget, int iTime, const char[] sReason);

--- a/scripting/lilac/lilac_lerp.sp
+++ b/scripting/lilac/lilac_lerp.sp
@@ -106,12 +106,16 @@ static void detected_nolerp(int client, float lerp)
 
 	playerinfo_banned_flags[client][CHEAT_NOLERP] = true;
 
+	char sDetails[512];
+	Format(sDetails, sizeof(sDetails), "%fms", lerp * 1000.0);
+
+	lilac_save_player_details(client, sDetails);
 	lilac_forward_client_cheat(client, CHEAT_NOLERP);
 
 	if (icvar[CVAR_LOG]) {
 		lilac_log_setup_client(client);
-		Format(line_buffer, sizeof(line_buffer), "%s was detected and banned for NoLerp (%fms).",
-			line_buffer, lerp * 1000.0);
+		Format(line_buffer, sizeof(line_buffer), "%s was detected and banned for NoLerp (%s).",
+			line_buffer, sDetails);
 
 		lilac_log(true);
 

--- a/scripting/lilac/lilac_macro.sp
+++ b/scripting/lilac/lilac_macro.sp
@@ -119,6 +119,10 @@ static void lilac_detected_macro(int client, int type)
 	default: { return; } /* Invalid type. */
 	}
 
+	char sDetails[512];
+	Format(sDetails, sizeof(sDetails), "Macro %s (Detection: %d | Max presses: %d)", string, macro_detected[client][type], macro_max);
+
+	lilac_save_player_details(client, sDetails);
 	lilac_forward_client_cheat(client, CHEAT_MACRO);
 
 	/* Ignore the first detection. */
@@ -129,8 +133,8 @@ static void lilac_detected_macro(int client, int type)
 	if (icvar[CVAR_LOG] && icvar[CVAR_MACRO] < 2) {
 		lilac_log_setup_client(client);
 		Format(line_buffer, sizeof(line_buffer),
-			"%s was detected of using Macro %s (Detection: %d | Max presses: %d).",
-			line_buffer, string, macro_detected[client][type], macro_max);
+			"%s was detected of using %s.",
+			line_buffer, sDetails);
 
 		lilac_log(true);
 

--- a/scripting/lilac/lilac_noisemaker.sp
+++ b/scripting/lilac/lilac_noisemaker.sp
@@ -143,6 +143,7 @@ static void lilac_detected_noisemaker(int client)
 
 	playerinfo_banned_flags[client][CHEAT_NOISEMAKER_SPAM] = true;
 
+	lilac_save_player_details(client, "N/A");
 	lilac_forward_client_cheat(client, CHEAT_NOISEMAKER_SPAM);
 
 	if (icvar[CVAR_LOG]) {

--- a/scripting/lilac/lilac_stock.sp
+++ b/scripting/lilac/lilac_stock.sp
@@ -102,6 +102,7 @@ void lilac_reset_client(int client)
 	playerinfo_time_teleported[client] = 0.0;
 	playerinfo_time_aimlock[client] = 0.0;
 	playerinfo_time_process_aimlock[client] = 0.0;
+	Format(playerinfo_detected[client], sizeof(playerinfo_detected[]), "");
 
 	for (int i = 0; i < CHEAT_MAX; i++) {
 		playerinfo_time_forward[client][i] = 0.0;
@@ -310,7 +311,7 @@ public Action timer_kick(Handle timer, int userid)
 
 	if (is_player_valid(client))
 		KickClient(client, "%T", "kick_ban_generic", client);
-		
+
 	return Plugin_Continue;
 }
 
@@ -431,6 +432,11 @@ bool is_player_valid(int client)
 		&& !IsClientSourceTV(client));
 }
 
+void lilac_save_player_details(int client, const char[] details)
+{
+	Format(playerinfo_detected[client], sizeof(playerinfo_detected[]), "%s", details);
+}
+
 void lilac_forward_client_cheat(int client, int cheat)
 {
 	int dummy;
@@ -473,4 +479,20 @@ bool lilac_forward_allow_cheat_detection(int client, int cheat)
 		return true;
 
 	return false;
+}
+
+public int lilac_native_get_detected_infos(Handle hPlugin, int numParams)
+{
+	int client = GetNativeCell(1);
+	if (!is_player_valid(client))
+		return -1;
+
+	if (!playerinfo_detected[client][0])
+		return -1;
+
+	int maxlen = GetNativeCell(3);
+	if (SetNativeString(2, playerinfo_detected[client], maxlen) == SP_ERROR_NONE)
+		return 1;
+
+	return -1;
 }

--- a/scripting/lilac/lilac_string.sp
+++ b/scripting/lilac/lilac_string.sp
@@ -81,13 +81,18 @@ public void OnClientSayCommand_Post(int client, const char[] command, const char
 			return;
 
 		playerinfo_banned_flags[client][CHEAT_CHATCLEAR] = true;
+
+		char sDetails[512];
+		Format(sDetails, sizeof(sDetails), "Chat message: %s", sArgs);
+
+		lilac_save_player_details(client, sDetails);
 		lilac_forward_client_cheat(client, CHEAT_CHATCLEAR);
 
 		if (icvar[CVAR_LOG]) {
 			lilac_log_setup_client(client);
 			Format(line_buffer, sizeof(line_buffer),
-				"%s was detected and banned for Chat-Clear (Chat message: %s)",
-				line_buffer, sArgs);
+				"%s was detected and banned for Chat-Clear (%s)",
+				line_buffer, sDetails);
 
 			lilac_log(true);
 
@@ -173,6 +178,8 @@ static void check_name(int client, const char []name)
 			return;
 
 		playerinfo_banned_flags[client][CHEAT_NEWLINE_NAME] = true;
+
+		lilac_save_player_details(client, name);
 		lilac_forward_client_cheat(client, CHEAT_NEWLINE_NAME);
 
 		if (icvar[CVAR_LOG]) {


### PR DESCRIPTION
Based on the review from https://github.com/J-Tanzanite/Little-Anti-Cheat/pull/155#issuecomment-1373056205

This PR does not include breaking change. *(so it safe for others plugins)*
It only introduce some improvements for API usage.

Changelogs:
- Added include file with Forwards
- Create a native `lilac_GetDetectedInfos` for get the detail of the detected cheat.
- Add docs to include
- Moved cheats definition to include
- Fix SM 1.11 syntax for `IRC_MsgFlaggedChannels`